### PR TITLE
Only load scripts on the Edit and New Post admin screens

### DIFF
--- a/includes/class-editorskit-block-assets.php
+++ b/includes/class-editorskit-block-assets.php
@@ -67,7 +67,7 @@ class EditorsKit_Block_Assets {
 		$this->_url     = untrailingslashit( plugins_url( '/', dirname( __FILE__ ) ) );
 
 		add_action( 'enqueue_block_assets', array( $this, 'block_assets' ) );
-		add_action( 'init', array( $this, 'editor_assets' ), 9999 );
+		add_action( 'admin_enqueue_scripts', array( $this, 'editor_assets' ), 9999 );
 	}
 
 	/**

--- a/includes/class-editorskit-block-assets.php
+++ b/includes/class-editorskit-block-assets.php
@@ -93,7 +93,7 @@ class EditorsKit_Block_Assets {
 	 */
 	public function editor_assets() {
 
-		if( !is_admin() ){
+		if( !is_admin() || !$this->is_edit_or_new_admin_page() ){
 			return;
 		}
 
@@ -113,6 +113,17 @@ class EditorsKit_Block_Assets {
 			time(),
 			false
 		);
+	}
+
+	/**
+	 * Checks if admin page is the 'edit' or 'new-post' screen.
+	 *
+	 * @return bool true or false
+	 */
+	function is_edit_or_new_admin_page() {
+		global $pagenow;
+
+		return ( is_admin() && ( $pagenow === 'post.php' || $pagenow === 'post-new.php' ) );
 	}
 
 }


### PR DESCRIPTION
Currently the plugin breaks the use of CMB2 used as an options page. This is because the admin scripts are being globally loaded instead of being loaded only when necessary. This patch limits the enqueuing of the editorkit scripts on the edit post and new post screens.