### PR TITLE
add markdown support for inline core using the ` attribute

### DIFF
--- a/src/extensions/formats/markdown/controls.js
+++ b/src/extensions/formats/markdown/controls.js
@@ -111,6 +111,10 @@ class MarkdownControl extends Component {
 				markdown: '~',
 				format: 'core/strikethrough',
 			},
+			code: {
+				markdown: '`',
+				format: 'core/code',
+			}
 		};
 
 		map( markdowns, ( markdown ) => {


### PR DESCRIPTION
I'm not sure wether that's really all, but if so it would be an awesome addition that in itself would make the plugin worth installing. Not even speaking of the rest  😂